### PR TITLE
Add ⭐️Weights & Biases⭐️ Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ output/**/*.*
 .DS_Store
 .vscode/
 local/
+wandb/

--- a/bin/autoint.py
+++ b/bin/autoint.py
@@ -512,4 +512,3 @@ for k, v in predictions.items():
 stats['time'] = lib.format_seconds(timer())
 save_checkpoint(True)
 print('Done!')
-wandb.finish()

--- a/bin/dcn2.py
+++ b/bin/dcn2.py
@@ -10,6 +10,7 @@ import torch.nn.functional as F
 import zero
 
 import lib
+import wandb
 
 
 # %%
@@ -224,6 +225,7 @@ def evaluate(parts):
 
 
 def save_checkpoint(final):
+    model_artifact = wandb.Artifact('dcn2-artifact', type='model')
     torch.save(
         {
             'model': model.state_dict(),
@@ -244,10 +246,13 @@ def save_checkpoint(final):
     )
     lib.dump_stats(stats, output, final)
     lib.backup_output(output)
+    model_artifact.add_file(checkpoint_path)
+    wandb.run.log_artifact(model_artifact)
 
 
 # %%
 timer.run()
+wandb.init(project="RTDL", config=args)
 for epoch in stream.epochs(args['training']['n_epochs']):
     print_epoch_info()
 
@@ -266,6 +271,7 @@ for epoch in stream.epochs(args['training']['n_epochs']):
             print('Loss is nan!')
             break
 
+        wandb.log({"Training Loss": loss})
         loss.backward()
         optimizer.step()
         epoch_losses.append(loss.detach())
@@ -278,8 +284,10 @@ for epoch in stream.epochs(args['training']['n_epochs']):
     print(f'[{lib.TRAIN}] loss = {round(sum(epoch_losses) / len(epoch_losses), 3)}')
 
     metrics, predictions = evaluate(lib.PARTS)
+    wandb.log({"score": metrics[lib.VAL]['score']})
     for k, v in metrics.items():
         training_log[k].append(v)
+        wandb.log({k:v})
     progress.update(metrics[lib.VAL]['score'])
 
     if progress.success:
@@ -289,6 +297,7 @@ for epoch in stream.epochs(args['training']['n_epochs']):
         save_checkpoint(False)
         for k, v in predictions.items():
             np.save(output / f'p_{k}.npy', v)
+            wandb.log({f"predictions_{k}": v})
 
     elif progress.fail:
         break
@@ -300,6 +309,8 @@ model.load_state_dict(torch.load(checkpoint_path)['model'])
 stats['metrics'], predictions = evaluate(lib.PARTS)
 for k, v in predictions.items():
     np.save(output / f'p_{k}.npy', v)
+    wandb.run.summary[f"final_prediction_{k}"] = v
 stats['time'] = lib.format_seconds(timer())
 save_checkpoint(True)
 print('Done!')
+wandb.finish()

--- a/bin/dcn2.py
+++ b/bin/dcn2.py
@@ -313,4 +313,3 @@ for k, v in predictions.items():
 stats['time'] = lib.format_seconds(timer())
 save_checkpoint(True)
 print('Done!')
-wandb.finish()

--- a/bin/ft_transformer.py
+++ b/bin/ft_transformer.py
@@ -539,4 +539,3 @@ if __name__ == "__main__":
     stats['time'] = lib.format_seconds(timer())
     save_checkpoint(True)
     print('Done!')
-    wandb.finish()

--- a/bin/grownet.py
+++ b/bin/grownet.py
@@ -492,6 +492,5 @@ lib.dump_stats(stats, output, final=True)
 for k, v in predictions.items():
     np.save(output / f'p_{k}.npy', v)
 lib.backup_output(output)
-wandb.finish()
 
 # %%

--- a/bin/lightgbm_.py
+++ b/bin/lightgbm_.py
@@ -8,7 +8,7 @@ import pandas as pd
 import zero
 from lightgbm import LGBMClassifier, LGBMRegressor
 import wandb
-from wandb.lightgbm import wandb_callback, log_summary
+from wandb.lightgbm import wandb_callback
 
 import lib
 
@@ -103,4 +103,3 @@ for part in X:
 stats['time'] = lib.format_seconds(timer())
 lib.dump_stats(stats, output, True)
 lib.backup_output(output)
-wandb.finish()

--- a/bin/lightgbm_.py
+++ b/bin/lightgbm_.py
@@ -7,6 +7,8 @@ import numpy as np
 import pandas as pd
 import zero
 from lightgbm import LGBMClassifier, LGBMRegressor
+import wandb
+from wandb.lightgbm import wandb_callback, log_summary
 
 import lib
 
@@ -78,11 +80,13 @@ else:
 
 timer = zero.Timer()
 timer.run()
-model.fit(
+wandb.init(project="RTDL", config=args)
+gbm = model.fit(
     X[lib.TRAIN],
     Y[lib.TRAIN],
     **fit_kwargs,
     eval_set=(X[lib.VAL], Y[lib.VAL]),
+    callbacks=[wandb_callback()]
 )
 if Path('catboost_info').exists():
     shutil.rmtree('catboost_info')
@@ -99,3 +103,4 @@ for part in X:
 stats['time'] = lib.format_seconds(timer())
 lib.dump_stats(stats, output, True)
 lib.backup_output(output)
+wandb.finish()

--- a/bin/mlp.py
+++ b/bin/mlp.py
@@ -280,4 +280,3 @@ for k, v in predictions.items():
 stats['time'] = lib.format_seconds(timer())
 save_checkpoint(True)
 print('Done!')
-wandb.finish()

--- a/bin/node.py
+++ b/bin/node.py
@@ -420,4 +420,3 @@ print(f'Done! Time elapsed: {stats["time_final"]}')
 print(
     '\n!!! WARNING !!! The metrics for a single model are stored under the "metrics_0" key.\n'
 )
-wandb.finish()

--- a/bin/resnet.py
+++ b/bin/resnet.py
@@ -11,7 +11,7 @@ import zero
 from torch import Tensor
 
 import lib
-
+import wandb
 
 # %%
 class ResNet(nn.Module):
@@ -230,6 +230,7 @@ if __name__ == "__main__":
         return metrics, predictions
 
     def save_checkpoint(final):
+        model_artifact = wandb.Artifact('resnet-artifact', type='model')
         torch.save(
             {
                 'model': model.state_dict(),
@@ -250,9 +251,13 @@ if __name__ == "__main__":
         )
         lib.dump_stats(stats, output, final)
         lib.backup_output(output)
+        model_artifact.add_file(checkpoint_path)
+        wandb.run.log_artifact(model_artifact)
+
 
     # %%
     timer.run()
+    wandb.init(project="RTDL", config=args)
     for epoch in stream.epochs(args['training']['n_epochs']):
         print_epoch_info()
 
@@ -267,6 +272,7 @@ if __name__ == "__main__":
                 ),
                 Y_device[lib.TRAIN][batch_idx],
             )
+            wandb.log({"Training Loss": loss})
             loss.backward()
             optimizer.step()
             epoch_losses.append(loss.detach())
@@ -275,8 +281,10 @@ if __name__ == "__main__":
         print(f'[{lib.TRAIN}] loss = {round(sum(epoch_losses) / len(epoch_losses), 3)}')
 
         metrics, predictions = evaluate([lib.VAL, lib.TEST])
+        wandb.log({"score": metrics[lib.VAL]['score']})
         for k, v in metrics.items():
             training_log[k].append(v)
+            wandb.log({k:v})
         progress.update(metrics[lib.VAL]['score'])
 
         if progress.success:
@@ -286,6 +294,7 @@ if __name__ == "__main__":
             save_checkpoint(False)
             for k, v in predictions.items():
                 np.save(output / f'p_{k}.npy', v)
+                wandb.log({f"predictions_{k}": v})
 
         elif progress.fail:
             break
@@ -296,6 +305,8 @@ if __name__ == "__main__":
     stats['metrics'], predictions = evaluate(lib.PARTS)
     for k, v in predictions.items():
         np.save(output / f'p_{k}.npy', v)
+        wandb.run.summary[f"final_prediction_{k}"] = v
     stats['time'] = lib.format_seconds(timer())
     save_checkpoint(True)
     print('Done!')
+    wandb.finish()

--- a/bin/resnet.py
+++ b/bin/resnet.py
@@ -309,4 +309,3 @@ if __name__ == "__main__":
     stats['time'] = lib.format_seconds(timer())
     save_checkpoint(True)
     print('Done!')
-    wandb.finish()

--- a/bin/snn.py
+++ b/bin/snn.py
@@ -323,4 +323,3 @@ for k, v in predictions.items():
 stats['time'] = lib.format_seconds(timer())
 save_checkpoint(True)
 print('Done!')
-wandb.finish()

--- a/bin/tabnet.py
+++ b/bin/tabnet.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 import zero
 
 import lib
+import wandb
 
 
 # %%
@@ -524,7 +525,7 @@ saver = tf.train.Saver()
 
 timer = zero.Timer()
 timer.run()
-
+wandb.init(project="RTDL", config=args)
 with tf.Session() as sess:
     sess.run(init)
     sess.run(init_local)
@@ -583,5 +584,7 @@ with tf.Session() as sess:
     saver.save(sess, str(output / "best.ckpt"))
     stats['time'] = zero.format_seconds(timer())
     lib.dump_stats(stats, output, final=True)
+    wandb.tensorflow.log(tf.summary.merge_all())
 
 print(f"Total time: {zero.format_seconds(timer())}")
+wandb.finish()

--- a/bin/tabnet.py
+++ b/bin/tabnet.py
@@ -587,4 +587,3 @@ with tf.Session() as sess:
     wandb.tensorflow.log(tf.summary.merge_all())
 
 print(f"Total time: {zero.format_seconds(timer())}")
-wandb.finish()

--- a/bin/xgboost_.py
+++ b/bin/xgboost_.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import numpy as np
 import zero
 from xgboost import XGBClassifier, XGBRegressor
+import wandb
+from wandb.xgboost import wandb_callback
 
 import lib
 
@@ -52,7 +54,9 @@ else:
 # Fit model
 timer = zero.Timer()
 timer.run()
-model.fit(X[lib.TRAIN], Y[lib.TRAIN], **fit_kwargs)
+wandb.init(project="RTDL", config=args)
+model.fit(X[lib.TRAIN], Y[lib.TRAIN], **fit_kwargs,
+                callbacks=[wandb_callback()])
 
 # Save model and metrics
 
@@ -69,3 +73,4 @@ for part in X:
 stats['time'] = lib.format_seconds(timer())
 lib.dump_stats(stats, output, True)
 lib.backup_output(output)
+wandb.finish()

--- a/bin/xgboost_.py
+++ b/bin/xgboost_.py
@@ -73,4 +73,3 @@ for part in X:
 stats['time'] = lib.format_seconds(timer())
 lib.dump_stats(stats, output, True)
 lib.backup_output(output)
-wandb.finish()


### PR DESCRIPTION
This PR aims to add basic [**Weights and Biases**](https://wandb.ai/site) Metric Logging by appending to the existing codebase with minimal changes while supporting Checkpoint uploads as Weights and Biases Artifacts.

Wherever needed, I have used the existing Weights and Biases integrations viz. LightGBM and XGBoost. 

I have validated the performance of all the proposed runs by running 150+ runs, which can be viewed on **[this project page](https://wandb.ai/sauravm/RTDL)** and in detail in an **[accompanying blog post](https://wandb.ai/sauravm/RTDL/reports/Revisiting-Deep-Learning-Models-for-Tabular-Data--VmlldzoxNDE1Njk0)**.