### PR TITLE
Fix MLP.make_baseline() return type

### DIFF
--- a/rtdl/modules.py
+++ b/rtdl/modules.py
@@ -1309,7 +1309,7 @@ class FTTransformer(nn.Module):
             transformer_config['head_activation'] = None
         if transformer_config['kv_compression_ratio'] is not None:
             transformer_config['n_tokens'] = feature_tokenizer.n_tokens + 1
-        return FTTransformer(
+        return cls(
             feature_tokenizer,
             Transformer(**transformer_config),
         )


### PR DESCRIPTION
Return object of type cls, not MLP, in MLP.make_baseline(). Otherwise, child classes inheriting from MLP constructed using the .make_baseline() method always have type MLP (instead of the type of the child class).