### PR TITLE
default argument 'd_intermidiate' for rtdl.ResNet.make_baseline function

### DIFF
--- a/examples/rtdl.ipynb
+++ b/examples/rtdl.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "18efc7f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,6 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "738bd206",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,6 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ecb9a82f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,6 +48,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "01805ba6",
    "metadata": {},
    "source": [
     "### Data"
@@ -53,6 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c14fbe88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,6 +111,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "50826758",
    "metadata": {},
    "source": [
     "### Model\n",
@@ -115,6 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "66d6637e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +139,7 @@
     "# model = rtdl.ResNet.make_baseline(\n",
     "#     d_in=X_all.shape[1],\n",
     "#     d_main=128,\n",
-    "#     d_intermidiate=256,\n",
+    "#     d_hidden=256,\n",
     "#     dropout_first=0.2,\n",
     "#     dropout_second=0.0,\n",
     "#     n_blocks=2,\n",
@@ -207,6 +214,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6764f049",
    "metadata": {},
    "source": [
     "### Training"
@@ -215,6 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "28bfc9fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,6 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b195897f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,6 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ca9126b3",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -305,7 +316,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -319,7 +330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
changed the default argument 'd_intermidiate' to d_hidden for rtdl.ResNet.make_baseline function in the examples folder. No argument named 'd_intermidiate'